### PR TITLE
Update home banner mobile view

### DIFF
--- a/src/components/home-banner/home-banner.component.js
+++ b/src/components/home-banner/home-banner.component.js
@@ -34,8 +34,7 @@ export default class HomeBanner extends React.Component {
 
     return (
       <div className="browse">
-        Or
-        <br/>
+        <span>or </span>
         <select onChange={this.props.onBrowseByEntityChange}>
           <option>{this.props.browseByText}</option>
           <option value="All">All</option>
@@ -94,13 +93,13 @@ export default class HomeBanner extends React.Component {
   get issueSection() {
     if (this.props.issueUrl) {
       return (
-        <div className="indented">
+        <div>
           <br/>
           <br/>
           <div className="banner-subsection">
             <div className="banner-subsection-subtitle" id="issue-banner-subsection-subtitle">
               <img className="chat" src={ASSET_PATH + 'assets/img/icons/chat_bubble.png'}/>
-              <span>Have questions or feedback? Open an issue on our open source repository <a className="link" href={this.props.issueUrl} id="issue-link" target="_blank">here</a>.</span>
+              <span>Have questions or feedback? Open an issue on our <a className="link" href={this.props.issueUrl} id="issue-link" target="_blank">open source repository</a>.</span>
             </div>
           </div>
         </div>

--- a/styles/home-banner.scss
+++ b/styles/home-banner.scss
@@ -5,7 +5,9 @@ section#banner-home {
 
   .banner-content {
 
-    padding-top: 60px;
+    padding-top: 100px;
+    position: absolute;
+    top: 50%;
 
     /* adds some additional spacing between sections */
     .indented {

--- a/styles/search.scss
+++ b/styles/search.scss
@@ -12,6 +12,8 @@
   }
 
   .search-description-wrapper {
+    font-size: 1.6rem;
+    font-weight: bold;
     margin: 0 auto;
     text-align: left;
     width: 100%;
@@ -27,21 +29,52 @@
     width: 100%;
 
     input {
+      height: 40px;
       /* 100% minus width of the button */
       width: calc(100% - 40px);
     }
 
     button.go {
+      border: 0px;
+      height: 40px;
       margin-right: 0;
       position: absolute;
     }
   }
 
   .icon-search {
-    color: black;
+    color: $color-black;
   }
 }
 
+.browse {
+  font-size: 1.6rem;
+  font-weight: bold;
+  margin-bottom: 4.5rem;
+  margin-top: 2rem;
+
+  select {
+    @include width-three-quarters();
+    background-color: $color-white;
+    border: .1rem solid $color-gray;
+    border-radius: 5px;
+    color: $color-black-light;
+    font-size: 1rem;
+    height: 3.7rem;
+    line-height: 1.3;
+    margin: 0;
+    padding: 1rem 3rem 1rem .7em;
+    text-transform: none;
+    vertical-align: middle;
+    width: 20rem;
+
+    @media screen and (min-width: $medium-screen) {
+      font-size: 1.4rem;
+      padding: .75rem 3rem .75rem .7em;
+    }
+
+  }
+}
 
 .search-results-content {
 
@@ -69,7 +102,6 @@
     .search-input-container {
         width: 100% !important;
     }
-
 
     .browse, .search-description-wrapper{
         display: none;


### PR DESCRIPTION
Updates to styling on the home page banner area. 
Incorporates previous updates for the mobile view, and home updates from @jlow81's recent [PR](https://github.com/GSA/code-gov-web/pull/704).

Before:
<img width="361" alt="screen shot 2018-10-29 at 5 57 23 pm" src="https://user-images.githubusercontent.com/2197515/47682865-1d731180-dba4-11e8-8f13-1c35ce22a364.png">


After:
<img width="413" alt="screen shot 2018-10-29 at 5 51 57 pm" src="https://user-images.githubusercontent.com/2197515/47682827-03393380-dba4-11e8-8e56-b00cd37a1de5.png">
