### PR TITLE
Fix data quality score

### DIFF
--- a/styles/repo-list.scss
+++ b/styles/repo-list.scss
@@ -3,7 +3,7 @@
 
   .data-quality-title {
     @media (max-width: 801px) {
-      display: none;
+      font-size: 1rem;
     }
   }
 }


### PR DESCRIPTION
Fixed data quality score text not showing on mobile. Closes #20.

AFTER
<img width="348" alt="screen shot 2018-11-05 at 2 40 19 pm" src="https://user-images.githubusercontent.com/2197515/48022300-d38cad00-e108-11e8-83fc-a6ddc1a37b67.png">
