### PR TITLE
Update pagination for mobile view

### DIFF
--- a/styles/repo-list.scss
+++ b/styles/repo-list.scss
@@ -27,28 +27,22 @@
 
 .repo-list-summary-wrapper,
 .ngx-pagination {
-  display: none;
+  display: block;
+  text-align: center;
 
-  @media screen and (min-width: $medium-screen) {
+  @media screen and (min-width: $large-screen) {
     display: inline-block;
   }
 }
 
-.repo-list-summary {
-  display: inline-block;
-  font-size: 0.8em;
-  line-height: 22px;
-  margin-bottom: 1rem;
-  margin-top: 0;
-}
-
 .card-list .ngx-pagination {
-  float: right;
-  font-size: 0.8em;
+  font-size: 1em;
   font-weight: bold;
-  margin: 0;
-  margin-top: 10px;
+  margin: 10px 0;
   user-select: none;
+  @media screen and (min-width: $large-screen) {
+    float: right;
+  }
 
   li {
     display: inline-block;
@@ -79,9 +73,16 @@
     }
   }
 
-  .page:not(.first) {
-    border-left: 2px solid $color-gray;
+  .page {
+    display: none;
+    @media screen and (min-width: $medium-screen) {
+      display: inline;
+      .page:not(.first) {
+        border-left: 2px solid $color-gray;
+      }
   }
+}
+
 
   .current {
     background: none;


### PR DESCRIPTION
Style updates to give the Pagination component a mobile-first (friendly) design on the Browse Projects, Search Results, and Open tasks pages.
Closes #35 and #34.

**Small screen:**
<img width="407" alt="screen shot 2018-11-07 at 9 23 42 am" src="https://user-images.githubusercontent.com/2197515/48136996-09e43c80-e26f-11e8-9948-676295e554f0.png">

**Medium screen:**
<img width="466" alt="screen shot 2018-11-07 at 9 23 55 am" src="https://user-images.githubusercontent.com/2197515/48136995-09e43c80-e26f-11e8-9cfc-00a211bbd75a.png">

**Large screen:**
<img width="969" alt="screen shot 2018-11-07 at 9 24 07 am" src="https://user-images.githubusercontent.com/2197515/48136994-09e43c80-e26f-11e8-960f-783b92602d8c.png">
